### PR TITLE
fix: use provideIn within the injectable decorator instead of adding …

### DIFF
--- a/projects/client/src/lib/dialog/dialog.module.ts
+++ b/projects/client/src/lib/dialog/dialog.module.ts
@@ -6,7 +6,6 @@ import { MatButtonModule, MatDialogModule, MatIconModule } from '@angular/materi
 import { TskDynamicContentModule } from '../dynamic-content/dynamic-content.module';
 
 import { TskDialogComponent } from './dialog.component';
-import { TskDialogService } from './dialog.service';
 
 @NgModule({
 	declarations: [
@@ -25,9 +24,6 @@ import { TskDialogService } from './dialog.service';
 		MatDialogModule,
 		MatIconModule,
 		TskDynamicContentModule
-	],
-	providers: [
-		TskDialogService
 	]
 })
 export class TskDialogModule {}

--- a/projects/client/src/lib/dialog/dialog.service.ts
+++ b/projects/client/src/lib/dialog/dialog.service.ts
@@ -5,7 +5,9 @@ import { TskDialogConfig } from './dialog-config';
 import { TskDialogComponent } from './dialog.component';
 
 /** service to quickly and easily open dialogs */
-@Injectable()
+@Injectable({
+	providedIn: 'root'
+})
 export class TskDialogService {
 	private static defaultConfig: Partial<TskDialogConfig> = {
 		actionButtons: [ { viewValue: 'Close', value: null } ],

--- a/projects/client/src/lib/theme/theme-selection.service.ts
+++ b/projects/client/src/lib/theme/theme-selection.service.ts
@@ -8,7 +8,9 @@ import { Theme } from './theme';
 import { ThemeGroup } from './theme-group';
 
 /** used to keep track of available themes and the currently selected theme */
-@Injectable()
+@Injectable({
+	providedIn: 'root'
+})
 export class TskThemeSelectionService<ThemeClassesT extends string | '' = any> {
 	updateOverlay = true;
 	private _defaultThemeClass: ThemeClassesT = '' as ThemeClassesT;

--- a/projects/client/src/lib/theme/theme.module.ts
+++ b/projects/client/src/lib/theme/theme.module.ts
@@ -4,7 +4,6 @@ import { FormsModule } from '@angular/forms';
 import { MatSelectModule } from '@angular/material';
 
 import { TskThemeSelectComponent } from './theme-select.component';
-import { TskThemeSelectionService } from './theme-selection.service';
 
 @NgModule({
 	imports: [
@@ -14,9 +13,6 @@ import { TskThemeSelectionService } from './theme-selection.service';
 	],
 	declarations: [
 		TskThemeSelectComponent
-	],
-	providers: [
-		TskThemeSelectionService
 	],
 	exports: [
 		TskThemeSelectComponent


### PR DESCRIPTION
…services to provider arrays to keep new instances from being used in lazy loaded routes